### PR TITLE
Add security to the API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'devise'
 gem 'font-awesome-rails'
 gem 'jquery-ui-rails'
+gem 'jwt'
 gem 'minitest-rails'
 gem 'simple_form'
 gem 'slim'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,7 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (6.0.1)
       railties (>= 3.2.16)
+    jwt (2.1.0)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -272,6 +273,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   jquery-ui-rails
+  jwt
   listen (~> 3.0.5)
   minitest-rails
   pg

--- a/app/controllers/admins/api_users_controller.rb
+++ b/app/controllers/admins/api_users_controller.rb
@@ -1,0 +1,16 @@
+class Admins::ApiUsersController < ApplicationController
+  before_action :authenticate_admin!
+
+  def index
+    @api_users = ApiUser.all
+    @api_user_ids = @api_users.map(&:id).join(',')
+  end
+
+  def destroy
+    ids = Array(params[:id].split(','))
+    ids.each do |id|
+      ApiUser.find(id).destroy
+    end
+    redirect_to admins_api_users_path, notice: "Deleted #{ids.size == 1 ? 'user' : 'all users'}"
+  end
+end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,10 +1,20 @@
 class ApiController < ActionController::Base
   protect_from_forgery with: :null_session, if: Proc.new {|c| c.request.format.json? }
 
+  before_action :authenticate_api_user!
+  before_action :check_token!
+
   rescue_from ActiveRecord::RecordInvalid, with: :render_unprocessable_entity_response
   rescue_from ActiveRecord::RecordNotFound, with: :render_not_found_response
 
   private
+
+  def check_token!
+    unless JwtTokenValidator.new(api_user: current_api_user, request: request, wrapper: JWTWrapper).valid?
+      sign_out current_api_user
+      render json: 'Token invalid or expired!'.to_json, status: :unauthorised
+    end
+  end
 
   def render_unprocessable_entity_response(exception)
     render json: exception.record.errors, status: :unprocessable_entity

--- a/app/controllers/api_users/registrations_controller.rb
+++ b/app/controllers/api_users/registrations_controller.rb
@@ -2,13 +2,13 @@ class ApiUsers::RegistrationsController < Devise::RegistrationsController
   protect_from_forgery with: :null_session, if: Proc.new { |c| c.request.format.json? }
 
   def new
+    @api_user = ApiUser.new
   end
 
   def create
-    @api_user = ApiUser.new(email: params[:email], password: params[:password], password_confirmation: params[:password])
-
+    @api_user = ApiUser.new(registration_params)
     if @api_user.save
-      render json: response_json
+      render json: { "Bearer Token" => JWTWrapper.encode({ api_user_id: @api_user.id }) }
     else
       render :new
     end
@@ -16,9 +16,7 @@ class ApiUsers::RegistrationsController < Devise::RegistrationsController
 
   private
 
-  def response_json
-    links_section = { "#POST" => new_api_user_session_url }
-    params_section = { email: @api_user.email, password: params[:password] }
-    { "_links" => links_section, "params" => params_section }.to_json
+  def registration_params
+    params.require(:registration).permit(:email, :password)
   end
 end

--- a/app/controllers/api_users/registrations_controller.rb
+++ b/app/controllers/api_users/registrations_controller.rb
@@ -1,0 +1,24 @@
+class ApiUsers::RegistrationsController < Devise::RegistrationsController
+  protect_from_forgery with: :null_session, if: Proc.new { |c| c.request.format.json? }
+
+  def new
+  end
+
+  def create
+    @api_user = ApiUser.new(email: params[:email], password: params[:password], password_confirmation: params[:password])
+
+    if @api_user.save
+      render json: response_json
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def response_json
+    links_section = { "#POST" => new_api_user_session_url }
+    params_section = { email: @api_user.email, password: params[:password] }
+    { "_links" => links_section, "params" => params_section }.to_json
+  end
+end

--- a/app/controllers/api_users/sessions_controller.rb
+++ b/app/controllers/api_users/sessions_controller.rb
@@ -1,0 +1,10 @@
+class ApiUsers::SessionsController < Devise::SessionsController
+  protect_from_forgery with: :null_session, if: Proc.new { |c| c.request.format.json? }
+
+  def new
+  end
+
+  def create
+    require "readline"; require "pry"; binding.pry 
+  end
+end

--- a/app/controllers/api_users/sessions_controller.rb
+++ b/app/controllers/api_users/sessions_controller.rb
@@ -5,6 +5,16 @@ class ApiUsers::SessionsController < Devise::SessionsController
   end
 
   def create
-    require "readline"; require "pry"; binding.pry 
+    api_user = ApiUser.find_by(email: session_params[:email])
+    if api_user && api_user.valid_password?(session_params[:password])
+      sign_in api_user
+      render json: { "Bearer Token" => JWTWrapper.encode({ api_user_id: api_user.id }) }
+    end
+  end
+
+  private
+
+  def session_params
+    params.require(:session).permit(:email, :password)
   end
 end

--- a/app/helpers/jwt_wrapper.rb
+++ b/app/helpers/jwt_wrapper.rb
@@ -1,0 +1,22 @@
+module JWTWrapper
+  extend self
+
+  def encode(payload, expiration = nil)
+    expiration ||= Rails.application.secrets.jwt_expiration_hours
+
+    payload = payload.dup
+    payload['exp'] = expiration.to_i.hours.from_now.to_i
+
+    JWT.encode payload, Rails.application.secrets.jwt_secret
+  end
+
+  def decode(token)
+    begin
+      decoded_token = JWT.decode token, Rails.application.secrets.jwt_secret
+
+      decoded_token.first
+    rescue
+      nil
+    end
+  end
+end

--- a/app/models/api_user.rb
+++ b/app/models/api_user.rb
@@ -1,0 +1,3 @@
+class ApiUser < ApplicationRecord
+  devise :database_authenticatable, :registerable, :validatable
+end

--- a/app/services/jwt_token_validator.rb
+++ b/app/services/jwt_token_validator.rb
@@ -1,0 +1,34 @@
+class JwtTokenValidator
+  def initialize(api_user:, request:, wrapper:)
+    @api_user = api_user
+    @request = request
+    @wrapper = wrapper
+    @token = {}
+    @strategy = ""
+  end
+
+  def valid?
+    extract_strategy_and_token_from_header
+    return false unless strategy == 'bearer'
+    token.has_key?('api_user_id') && api_user.id == token['api_user_id']
+  end
+
+  private
+
+  def authorization_header
+    @authorization_header ||= begin
+                                @request.headers['Authorization'].to_s.split
+                              rescue
+                                nil
+                              end
+  end
+
+  def extract_strategy_and_token_from_header
+    return unless authorization_header && authorization_header.size == 2
+    @strategy = authorization_header[0].downcase
+    @token = @wrapper.decode(authorization_header[1]) || {}
+  end
+
+  attr_reader :api_user, :request, :wrapper
+  attr_accessor :strategy, :token
+end

--- a/app/views/admins/api_users/_users_table.html.slim
+++ b/app/views/admins/api_users/_users_table.html.slim
@@ -1,0 +1,16 @@
+table.table.table-sm.table-striped.table-bordered
+  thead
+    tr
+      th scope='col'
+        | Name
+      th.actions scope='col'
+        | Actions
+  tbody
+    - users.each do |user|
+      tr
+        td
+          = user.email
+        td.actions
+          .btn-group
+            = link_to admins_api_user_path(user), data: { confirm: 'Are you sure?' }, method: :delete, class: 'btn btn-sm btn-danger' do
+              = fa_icon 'remove', text: 'Delete'

--- a/app/views/admins/api_users/index.html.slim
+++ b/app/views/admins/api_users/index.html.slim
@@ -1,0 +1,15 @@
+.row
+  .col
+    h3
+      | Manage Api Users
+  .col
+    - unless @api_user_ids == ""
+      .btn-group.float-right
+        = link_to admins_api_user_path(@api_user_ids), data: { confirm: 'Are you sure?' }, method: :delete, class: 'btn btn-sm btn-danger' do
+          = fa_icon 'remove', text: 'Delete All Api Users'
+
+- if @api_users.size > 0
+  = render partial: 'users_table', locals: { users: @api_users }
+- else
+  p.lead
+    | There are no API Users

--- a/app/views/api_users/registrations/new.json.jbuilder
+++ b/app/views/api_users/registrations/new.json.jbuilder
@@ -1,0 +1,6 @@
+body = { "email" => "my@email.com", "password" => "password1" }
+json._errors @api_user.errors.full_messages unless @api_user.errors.empty?
+json._links do
+  json.POST api_user_registration_url
+  json.body body
+end

--- a/app/views/api_users/sessions/new.json.jbuilder
+++ b/app/views/api_users/sessions/new.json.jbuilder
@@ -1,0 +1,5 @@
+json.alert flash[:alert] if flash[:alert]
+json._links do
+  json.signIn api_user_session_url
+  json.signUp new_api_user_registration_url
+end

--- a/app/views/application/_admin_sidebar.html.slim
+++ b/app/views/application/_admin_sidebar.html.slim
@@ -3,5 +3,8 @@ ul.nav.flex-column.sidebar
     = link_to root_path, class: 'nav-link' do
       = fa_icon 'home', text: 'Dashboard'
   li.nav-item
+    = link_to admins_api_users_path, class: 'nav-link' do
+      = fa_icon 'users', text: 'Manage Api Users'
+  li.nav-item
     = link_to admins_schools_path, class: 'nav-link' do
       = fa_icon 'institution', text: 'Manage Schools'

--- a/config/initializers/core_extensions/devise/strategies/json_web_token.rb
+++ b/config/initializers/core_extensions/devise/strategies/json_web_token.rb
@@ -1,0 +1,35 @@
+module Devise
+  module Strategies
+    class JsonWebToken < Base
+      def valid?
+        bearer_header.present?
+      end
+
+      def authenticate!
+        return if no_claims_or_no_claimed_api_user_id
+
+        success! ApiUser.find_by_id claims['api_user_id']
+      end
+
+      protected
+
+      def bearer_header
+        request.headers['Authorization']&.to_s
+      end
+
+      def no_claims_or_no_claimed_api_user_id
+        !claims || !claims.has_key?('api_user_id')
+      end
+
+      private
+
+      def claims
+        strategy, token = bearer_header.split(' ')
+
+        return nil if (strategy || '').downcase != 'bearer'
+
+        JWTWrapper.decode(token) rescue nil
+      end
+    end
+  end
+end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -3,13 +3,18 @@
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
+  config.warden do |manager|
+    manager.strategies.add(:jwt, Devise::Strategies::JsonWebToken)
+    manager.default_strategies(scope: :api_user).unshift :jwt
+  end
+
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
   # config.secret_key = 'ed83b05632f447d358f235c886ed5da82452797abf7044bd0e09fffaea1d8c2f94f5f4f2a7e105c1e18212bbd26c0c8c92455eed458ae7733317fa77e4db077a'
-  
+
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.
   # config.parent_controller = 'DeviseController'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
   authenticated :admin do
     namespace :admins do
       root 'dashboard#index'
+      resources :api_users, only: [:index, :destroy]
       resources :schools do
         resources :messages, only: [:destroy]
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  devise_for :api_users, path: 'api', controllers: { sessions: 'api_users/sessions', registrations: 'api_users/registrations' }
+
   namespace :api do
     namespace :v1 do
       resources :schools, only: [:index, :show] do

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -12,9 +12,13 @@
 
 development:
   secret_key_base: 5e1f10a12be133651e42e19f17069cae52aedaf7f9ef0e5b67d71064523d237133f94d334ea1c9437826335fd001ee07d0c090a36bac8819f675a28fd33c22e9
+  jwt_secret: f9721783ceb13e29fae638d9e52efe332f35fb9c20fed6be7827497cfb1a0ee768c43dcc2ac799a65a92948e2e3bac3390b32d7881a0f3846250a7611a90702f
+  jwt_expiration_hours: 24
 
 test:
   secret_key_base: 7222dfa8ad5ee3f31e50a3dd9359ae89587abd02b8d9a7cdaf5ee7505c46f3ff07e587cfa1491568c527f85f2227379f3e76ba8fc52a0ebfe157859c5b513a7e
+  jwt_secret: f9721783ceb13e29fae638d9e52efe332f35fb9c20fed6be7827497cfb1a0ee768c43dcc2ac799a65a92948e2e3bac3390b32d7881a0f3846250a7611a90702f
+  jwt_expiration_hours: 24
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.

--- a/db/migrate/20180917031833_devise_create_api_users.rb
+++ b/db/migrate/20180917031833_devise_create_api_users.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class DeviseCreateApiUsers < ActiveRecord::Migration[5.0]
+  def change
+    create_table :api_users do |t|
+      t.string :email, null: false, default: ''
+      t.string :encrypted_password, null: false, default: ''
+      t.string :reset_password_token
+      t.timestamps
+    end
+    add_index :api_users, :email, unique: true
+    add_index :api_users, :reset_password_token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180916160426) do
+ActiveRecord::Schema.define(version: 20180917031833) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,16 @@ ActiveRecord::Schema.define(version: 20180916160426) do
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_admins_on_email", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true, using: :btree
+  end
+
+  create_table "api_users", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_api_users_on_email", unique: true, using: :btree
+    t.index ["reset_password_token"], name: "index_api_users_on_reset_password_token", unique: true, using: :btree
   end
 
   create_table "messages", force: :cascade do |t|

--- a/test/controllers/admins/api_users_controller_test.rb
+++ b/test/controllers/admins/api_users_controller_test.rb
@@ -1,0 +1,75 @@
+require 'test_helper'
+
+class Admins::ApiUsersControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  describe 'GET #index' do
+    it 'will not have a root to admins path if not logged in as admin' do
+      assert_raises ActionController::RoutingError do
+        get admins_api_users_path
+      end
+    end
+
+    it 'will not have a root to admins when logged in as user' do
+      assert_raises ActionController::RoutingError do
+        user = FactoryBot.create(:user)
+        sign_in user
+        get admins_api_users_path
+      end
+    end
+
+    it 'will respond :success when logged in as an admin with no users' do
+      admin = FactoryBot.create(:admin)
+      sign_in admin
+      get admins_api_users_path
+      assert_response :success
+    end
+
+    it 'will respond :success when logged in as an admin with users' do
+      FactoryBot.create(:api_user)
+      admin = FactoryBot.create(:admin)
+      sign_in admin
+      get admins_api_users_path
+      assert_response :success
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    it 'will not have a root to admins path if not logged in as admin' do
+      assert_raises ActionController::RoutingError do
+        api_user = FactoryBot.create(:api_user)
+        delete admins_api_user_path(api_user)
+      end
+    end
+
+    it 'will not have a root to admins when logged in as user' do
+      assert_raises ActionController::RoutingError do
+        user = FactoryBot.create(:user)
+        sign_in user
+        api_user = FactoryBot.create(:api_user)
+        delete admins_api_user_path(api_user)
+      end
+    end
+
+    it 'will destroy user' do
+      api_user = FactoryBot.create(:api_user)
+      admin = FactoryBot.create(:admin)
+      sign_in admin
+      assert_difference 'ApiUser.count',-1 do
+        delete admins_api_user_path(api_user)
+      end
+    end
+
+    it 'will destroy all users when passed ids in format of 1,2,3,4' do
+      5.times do |i|
+        FactoryBot.create(:api_user, email: "email#{i}@email.com")
+      end
+      ids = ApiUser.all.map(&:id).join(',')
+      admin = FactoryBot.create(:admin)
+      sign_in admin
+      assert_difference 'ApiUser.count',-5 do
+        delete admins_api_user_path(ids)
+      end
+    end
+  end
+end

--- a/test/controllers/api/v1/messages_controller_test.rb
+++ b/test/controllers/api/v1/messages_controller_test.rb
@@ -1,52 +1,101 @@
 require 'test_helper'
 
 class Api::V1::MessagesControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
   describe 'GET #index' do
-    it 'will respond with :success' do
+    it 'will respond with :unauthorized when not logged in' do
       school = FactoryBot.create(:school)
       get api_v1_school_messages_url(school, format: :json)
+      assert_response :unauthorized
+    end
+
+    it 'will respond with :error when logged in with an invalid token' do
+      api_user = FactoryBot.create(:api_user)
+      sign_in api_user
+      school = FactoryBot.create(:school)
+      get api_v1_school_messages_url(school, format: :json)
+      assert_response :error
+    end
+
+    it 'will respond with :success when logged in with a valid token' do
+      api_user = FactoryBot.create(:api_user)
+      sign_in api_user
+      token = "Bearer #{JWTWrapper.encode({ api_user_id: api_user.id })}"
+      school = FactoryBot.create(:school)
+      get api_v1_school_messages_url(school, format: :json), headers: { 'Authorization': token }
       assert_response :success
     end
   end
 
   describe 'GET #show' do
-    it 'will respond with :success' do
+    it 'will respond with :unauthorized when not logged in' do
       FactoryBot.create(:school_message)
       school = School.first
       message = Message.first
       get api_v1_school_message_url(school, message, format: :json)
+      assert_response :unauthorized
+    end
+
+    it 'will respond with :error when logged in with a invalid token' do
+      api_user = FactoryBot.create(:api_user)
+      sign_in api_user
+      FactoryBot.create(:school_message)
+      school = School.first
+      message = Message.first
+      get api_v1_school_message_url(school, message, format: :json)
+      assert_response :error
+    end
+
+    it 'will respond with :success when logged in with a valid token' do
+      api_user = FactoryBot.create(:api_user)
+      sign_in api_user
+      token = "Bearer #{JWTWrapper.encode({ api_user_id: api_user.id })}"
+      FactoryBot.create(:school_message)
+      school = School.first
+      message = Message.first
+      get api_v1_school_message_url(school, message, format: :json), headers: { 'Authorization': token }
       assert_response :success
     end
   end
 
   describe 'POST #create' do
     it 'will redirect to message api when successful' do
+      api_user = FactoryBot.create(:api_user)
+      sign_in api_user
+      token = "Bearer #{JWTWrapper.encode({ api_user_id: api_user.id })}"
       school = FactoryBot.create(:school)
       params = { message: { header: 'This is the header', body: 'This is the body' } }
       assert_difference('Message.count') do
-        post api_v1_school_messages_url(school, format: :json), params: params
+        post api_v1_school_messages_url(school, format: :json), params: params, headers: { 'Authorization': token }
       end
     end
   end
 
   describe 'PATCH #update' do
     it 'will redirect to the message api when successul' do
+      api_user = FactoryBot.create(:api_user)
+      sign_in api_user
+      token = "Bearer #{JWTWrapper.encode({ api_user_id: api_user.id })}"
       FactoryBot.create(:school_message)
       school = School.first
       message = Message.first
       params = { message: { header: 'new header'} }
-      patch api_v1_school_message_url(school, message, format: :json), params: params
+      patch api_v1_school_message_url(school, message, format: :json), params: params, headers: { 'Authorization': token }
       assert_redirected_to api_v1_school_message_url(school, message, format: :json)
     end
   end
 
   describe 'DELETE #delete' do
     it 'will redirect to the message api when successul' do
+      api_user = FactoryBot.create(:api_user)
+      sign_in api_user
+      token = "Bearer #{JWTWrapper.encode({ api_user_id: api_user.id })}"
       FactoryBot.create(:school_message)
       school = School.first
       message = Message.first
       assert_difference 'Message.count', -1 do
-        delete api_v1_school_message_url(school, message, format: :json)
+        delete api_v1_school_message_url(school, message, format: :json), headers: { 'Authorization': token }
       end
     end
   end

--- a/test/controllers/api/v1/schools_controller_test.rb
+++ b/test/controllers/api/v1/schools_controller_test.rb
@@ -1,17 +1,51 @@
 require 'test_helper'
 
 class Api::V1::SchoolsControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
   describe 'GET #index' do
-    it 'will respond with :success' do
+    it 'will respond with :unauthorized when not logged in' do
       get api_v1_schools_url(format: :json)
+      assert_response :unauthorized
+    end
+
+    it 'will respond with :error logged_in without valid token' do
+      api_user = FactoryBot.create(:api_user)
+      sign_in api_user
+      get api_v1_schools_url(format: :json)
+      assert_response :error
+    end
+
+    it 'will respond with :success logged_in with a valid token' do
+      api_user = FactoryBot.create(:api_user)
+      sign_in api_user
+      token = "Bearer #{JWTWrapper.encode({ api_user_id: api_user.id })}"
+      get api_v1_schools_url(format: :json), headers: { 'Authorization': token }
       assert_response :success
     end
   end
 
   describe 'GET #show' do
-    it 'will respond with :success' do
+    it 'will respond with :unauthorized when logged in with a valid token' do
       school = FactoryBot.create(:school)
       get api_v1_school_url(school, format: :json)
+      assert_response :unauthorized
+    end
+
+    it 'will respond with :error when logged in with a valid token' do
+      api_user = FactoryBot.create(:api_user)
+      sign_in api_user
+      school = FactoryBot.create(:school)
+      get api_v1_school_url(school, format: :json)
+      assert_response :error
+    end
+
+    it 'will respond with :success when logged in with a valid token' do
+      api_user = FactoryBot.create(:api_user)
+      sign_in api_user
+      token = "Bearer #{JWTWrapper.encode({ api_user_id: api_user.id })}"
+      school = FactoryBot.create(:school)
+      get api_v1_school_url(school, format: :json), headers: { 'Authorization': token }
       assert_response :success
     end
   end

--- a/test/factories/api_user.rb
+++ b/test/factories/api_user.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :api_user do
+    email { 'russellwakefield4@gmail.com' }
+    password { 'passw0rd!' }
+    password_confirmation { 'passw0rd!' }
+  end
+end

--- a/test/models/api_user_test.rb
+++ b/test/models/api_user_test.rb
@@ -1,0 +1,8 @@
+require 'test_helper'
+
+describe 'ApiUser' do
+  it 'must be valid' do
+    api_user = build :api_user
+    api_user.valid?.must_equal true
+  end
+end

--- a/test/services/jwt_token_validator_test.rb
+++ b/test/services/jwt_token_validator_test.rb
@@ -1,0 +1,79 @@
+require 'test_helper'
+
+
+describe 'JwtTokenValidator' do
+  describe '#valid?' do
+    before do
+      @wrapper = JWTWrapper
+      @request_struct = Struct.new(:headers)
+    end
+
+    it 'will return false if the request has no headers' do
+      api_user = create :api_user
+      request = @request_struct.new(nil)
+      validator = JwtTokenValidator.new(api_user: api_user, request: request, wrapper: @wrapper)
+      validator.valid?.must_equal false
+    end
+
+    it 'will return false if thee request header does not contain Authorization' do
+      api_user = create :api_user
+      request = @request_struct.new({})
+      validator = JwtTokenValidator.new(api_user: api_user, request: request, wrapper: @wrapper)
+      validator.valid?.must_equal false
+    end
+
+    it 'will return false if the token is prepended' do
+      api_user = create :api_user
+      token = @wrapper.encode({ api_user_id: api_user.id })
+      headers = { 'Authorization' => "#{token}" }
+      request = @request_struct.new(headers)
+      validator = JwtTokenValidator.new(api_user: api_user, request: request, wrapper: @wrapper)
+      validator.valid?.must_equal false
+    end
+
+    it 'will return false if the strategy is not Bearer' do
+      api_user = create :api_user
+      token = @wrapper.encode({ api_user_id: api_user.id })
+      headers = { 'Authorization' => "NOTBEARER #{token}" }
+      request = @request_struct.new(headers)
+      validator = JwtTokenValidator.new(api_user: api_user, request: request, wrapper: @wrapper)
+      validator.valid?.must_equal false
+    end
+
+    it 'will return false if the token does not match the encoded token' do
+      api_user = create :api_user
+      token = @wrapper.encode({ api_user_id: api_user.id })
+      headers = { 'Authorization' => "Bearer NOT_THE_TOKEN_YOU_ARE_LOOKING_FOR" }
+      request = @request_struct.new(headers)
+      validator = JwtTokenValidator.new(api_user: api_user, request: request, wrapper: @wrapper)
+      validator.valid?.must_equal false
+    end
+
+    it 'will return false if the token does not have the key api_user_id' do
+      api_user = create :api_user
+      token = @wrapper.encode({ not_the_token_you_are_looking_for: api_user.id })
+      headers = { 'Authorization' => "Bearer #{token}" }
+      request = @request_struct.new(headers)
+      validator = JwtTokenValidator.new(api_user: api_user, request: request, wrapper: @wrapper)
+      validator.valid?.must_equal false
+    end
+
+    it 'will return false if the token does not exist' do
+      api_user = create :api_user
+      token = @wrapper.encode({ api_user_id: api_user.id })
+      headers = { 'Authorization' => nil }
+      request = @request_struct.new(headers)
+      validator = JwtTokenValidator.new(api_user: api_user, request: request, wrapper: @wrapper)
+      validator.valid?.must_equal false
+    end
+
+    it 'will return true with a valid setup' do
+      api_user = create :api_user
+      token = @wrapper.encode({ api_user_id: api_user.id })
+      headers = { 'Authorization' => "Bearer #{token}" }
+      request = @request_struct.new(headers)
+      validator = JwtTokenValidator.new(api_user: api_user, request: request, wrapper: @wrapper)
+      validator.valid?.must_equal true
+    end
+  end
+end


### PR DESCRIPTION
This PR integrates Devise with JsonWebToken and Warden to add security to the API

### Changes:
* add devise model for api_users
* modify devise views and controllers to walk user through the sign in process
* set up JsonWebToken validator for devise
* add filter to check the JsonWebToken when using the API
* add section to the admin users page to delete api_users

### Screenshots

#### Redirected When Not logged In
![screen shot 2018-09-18 at 12 21 01 am](https://user-images.githubusercontent.com/1315826/45664280-00ddb700-bad9-11e8-8e98-674df43ef21f.png)

#### Given Suggested Login Info When Visiting Sign Up
![screen shot 2018-09-18 at 12 21 17 am](https://user-images.githubusercontent.com/1315826/45664297-14891d80-bad9-11e8-9f48-f9836fd964aa.png)

#### Given Token When Signed Up
![screen shot 2018-09-18 at 12 22 02 am](https://user-images.githubusercontent.com/1315826/45664327-2e2a6500-bad9-11e8-9754-83b002c43617.png)

#### Can View API Once Token is Added to Header
![screen shot 2018-09-18 at 12 22 24 am](https://user-images.githubusercontent.com/1315826/45664349-469a7f80-bad9-11e8-8ec8-95e2029442a6.png)

#### API Errors when Token Expires or Changes
![screen shot 2018-09-18 at 12 25 44 am](https://user-images.githubusercontent.com/1315826/45664364-68940200-bad9-11e8-8e6e-881dd15af820.png)

#### Admins Can Destroy API Users
![screen shot 2018-09-18 at 12 29 21 am](https://user-images.githubusercontent.com/1315826/45664470-eb1cc180-bad9-11e8-9c30-39daf684ef52.png)

